### PR TITLE
SOCINT-19 upgrade to spring boot 2.5.0

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -136,6 +136,18 @@
       <artifactId>logging</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <!-- Testing -->
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
 
   <properties>
-    <springboot.version>2.3.0.RELEASE</springboot.version>
+    <springboot.version>2.5.0</springboot.version>
     <java.version>11</java.version>
     <jacoco.version>0.8.3</jacoco.version>
     <orika.version>1.5.2</orika.version>
@@ -74,7 +74,7 @@
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
-        <version>1.0.4.RELEASE</version>
+        <version>2.0.2</version>
       </dependency>
 
       <!-- need separate jaxb deps after java11 removed them -->

--- a/product-reference/src/test/resources/logback-test.xml
+++ b/product-reference/src/test/resources/logback-test.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<!-- quiet tests -->
+<configuration/>

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-framework</artifactId>
@@ -48,8 +50,18 @@
       <artifactId>google-cloud-firestore</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
-        <!-- ONS libraries -->
+    <!-- ONS libraries -->
 
     <dependency>
       <groupId>ons.sdc.int.common</groupId>


### PR DESCRIPTION
In order to support latest Postgres (version 13) without warnings from Spring, we upgrade Spring Boot version to latest (2.5.0) from existing 2.3.0-RELEASE.

This includes an upgrade of the circuit-breaker code, and some Junit compatibility pom additions (see Spring 2.4.0 release notes for Junit guidance).