### PR TITLE
SOCINT-138 minor rename of event publisher static factory method and …

### DIFF
--- a/event-publisher/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
+++ b/event-publisher/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
@@ -92,7 +92,7 @@ public class EventPublisherTest {
 
   @Test
   public void shouldCreateWithEventPersistence() {
-    EventPublisher ep = EventPublisher.createWithEventPersistence(sender, eventPersistence, null);
+    EventPublisher ep = EventPublisher.create(sender, eventPersistence, null);
     assertNotNull(ReflectionTestUtils.getField(ep, "eventPersistence"));
     assertEquals(sender, ReflectionTestUtils.getField(ep, "sender"));
   }


### PR DESCRIPTION
…logging tweak

Minor changes to have sensible static factory method name, and logging for when CCSvc creates an `EventPublisher` without the backup persistence, but with the circuit-breaker still in place.   
