### PR TITLE
Socint 243 robust event publisher tests

### DIFF
--- a/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/model/UacUpdate.java
+++ b/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/model/UacUpdate.java
@@ -13,7 +13,7 @@ public class UacUpdate implements EventPayload {
 
   private String caseId;
 
-  private String active;
+  private boolean active;
 
   @LoggingScope(scope = Scope.MASK)
   private String uacHash;

--- a/event-publisher/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherWithoutPersistenceTest.java
+++ b/event-publisher/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherWithoutPersistenceTest.java
@@ -18,7 +18,7 @@ import uk.gov.ons.ctp.common.event.model.SurveyLaunchResponse;
 
 /** EventPublisher tests specific to the scenario in which event persistence is turned off. */
 @ExtendWith(MockitoExtension.class)
-public class EventPublisherWithoutPersistanceTest {
+public class EventPublisherWithoutPersistenceTest {
 
   @InjectMocks private EventPublisher eventPublisher;
   @Mock private EventSender sender;

--- a/event-publisher/src/test/java/uk/gov/ons/ctp/common/event/PubSubEventSenderTest.java
+++ b/event-publisher/src/test/java/uk/gov/ons/ctp/common/event/PubSubEventSenderTest.java
@@ -1,0 +1,102 @@
+package uk.gov.ons.ctp.common.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.spring.pubsub.core.PubSubTemplate;
+import com.google.common.reflect.ClassPath;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import java.lang.reflect.Array;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.annotation.AsyncResult;
+import org.springframework.util.concurrent.ListenableFuture;
+import uk.gov.ons.ctp.common.FixtureHelper;
+import uk.gov.ons.ctp.common.event.model.GenericEvent;
+import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+public class PubSubEventSenderTest {
+
+  @Mock PubSubTemplate template;
+
+  private PubSubEventSender sender;
+
+  private ObjectMapper mapper = new CustomObjectMapper();
+
+  private int count;
+  private static final EventTopic ANY_TOPIC = EventTopic.CASE_UPDATE;
+  private static final int ANY_TIMEOUT = 3;
+
+  @Captor private ArgumentCaptor<PubsubMessage> pubsubMsgCaptor;
+
+  @BeforeEach
+  public void setup() {
+    sender = new PubSubEventSender(template, ANY_TIMEOUT);
+
+    ListenableFuture<String> futureAck = new AsyncResult<String>("ACK");
+    lenient().when(template.publish(any(), any())).thenReturn(futureAck);
+  }
+
+  /**
+   * Loop over all the model Event items, and for each one test that the fixture JSON file matches
+   * that sent.
+   *
+   * <p>The test will fail on mismatches in expectation of types (eg boolean to string implicit
+   * conversion). See <b>SOCINT-243</b> for description of problem.
+   *
+   * <p>Note: this test requires that each fixture JSON is NOT in an array, since the {@link
+   * FixtureHelper#loadPackageObjectNode} method expects that restriction. It also requires a
+   * fixture JSON file for each and every subclass of {@link GenericEvent}.
+   *
+   * @throws Exception on test failure
+   */
+  @Test
+  public void shouldSendAllEventsAsExpected() throws Exception {
+    ClassPath cp = ClassPath.from(this.getClass().getClassLoader());
+    var classInfos = cp.getTopLevelClasses(this.getClass().getPackageName() + ".model");
+    for (var inf : classInfos) {
+      String className = inf.getSimpleName();
+      if (className.endsWith("Event") && !className.equals("GenericEvent")) {
+        @SuppressWarnings("unchecked")
+        var clazz = (Class<? extends GenericEvent>) inf.load();
+        count++;
+        verifyEventSentIsExpectedJson(clazz);
+      }
+    }
+  }
+
+  private <T extends GenericEvent> void verifyEventSentIsExpectedJson(Class<T> clazz)
+      throws Exception {
+    @SuppressWarnings("unchecked")
+    var arrClazz = (Class<T[]>) Array.newInstance(clazz, 0).getClass();
+
+    GenericEvent event = FixtureHelper.loadPackageFixtures(arrClazz).get(0);
+
+    sender.sendEvent(ANY_TOPIC, event);
+
+    verify(template, times(count)).publish(eq(ANY_TOPIC.getTopic()), pubsubMsgCaptor.capture());
+
+    PubsubMessage pubsubMessage = pubsubMsgCaptor.getValue();
+    ByteString data = pubsubMessage.getData();
+    String json = data.toStringUtf8();
+
+    JsonNode node = mapper.readTree(json);
+    var origNode = FixtureHelper.loadPackageObjectNode(clazz.getSimpleName());
+
+    assertEquals(
+        origNode, node, "Failed to send expected JSON for class: " + clazz.getSimpleName());
+  }
+}

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.CaseEvent.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.CaseEvent.json
@@ -1,45 +1,43 @@
-[
-  {
-    "header": {
-      "version": "0.4.0",
-      "topic": "event_case-update",
-      "source": "RESPONDENT_HOME",
-      "channel": "RH",
-      "dateTime": "2020-06-29T13:25:36.042Z",
-      "messageId": "191f7c80-4774-4e1b-a52c-ef8c209b90e4",
-      "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
-      "originatingUser": "RESPONDENT_HOME"
-    },
-    "payload": {
-      "caseUpdate": {
-        "caseId": "2883af91-0052-4497-9805-3238544fcf8a",
-        "caseRef": "10000000017",
-        "surveyId": "2883af91-0052-4497-9805-3238544fcf8a",
-        "collectionExerciseId": "3883af91-0052-4497-9805-3238544fcf8a",
-        "invalid": true,
-        "refusalReceived": "HARD_REFUSAL",
-        "sample": {
-          "addressLine1": "Flat 987, Magical Apartments",
-          "addressLine2": "123 Fake Street",
-          "addressLine3": "Some Suburb",
-          "townName": "Fake Town",
-          "postcode": "AB1 2ZX",
-          "region": "W",
-          "uprn": "123456789",
-          "questionnaire": "dummy_9wbthzvgj6",
-          "sampleUnitRef": "dummy_6zfd5iq9pg",
-          "cohort": "7",
-          "gor9d": "dummy_99n62dhi40",
-          "laCode": "dummy_p468dsuyo5",
-          "uprnLatitude": "52.35064053950229",
-          "uprnLongitude": "-1.580400903268521"
-        },
-        "sampleSensitive": {
-          "phoneNumber": "REDACTED"
-        },
-        "createdAt": "2021-01-01T01:02:03.456Z",
-        "lastUpdatedAt": "2021-10-10T00:00:00.000Z"
-      }
+{
+  "header": {
+    "version": "0.4.0",
+    "topic": "event_case-update",
+    "source": "RESPONDENT_HOME",
+    "channel": "RH",
+    "dateTime": "2020-06-29T13:25:36.042Z",
+    "messageId": "191f7c80-4774-4e1b-a52c-ef8c209b90e4",
+    "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
+    "originatingUser": "RESPONDENT_HOME"
+  },
+  "payload": {
+    "caseUpdate": {
+      "caseId": "2883af91-0052-4497-9805-3238544fcf8a",
+      "surveyId": "2883af91-0052-4497-9805-3238544fcf8a",
+      "collectionExerciseId": "3883af91-0052-4497-9805-3238544fcf8a",
+      "invalid": true,
+      "refusalReceived": "HARD_REFUSAL",
+      "sample": {
+        "addressLine1": "Flat 987, Magical Apartments",
+        "addressLine2": "123 Fake Street",
+        "addressLine3": "Some Suburb",
+        "townName": "Fake Town",
+        "postcode": "AB1 2ZX",
+        "region": "W",
+        "uprn": "123456789",
+        "questionnaire": "dummy_9wbthzvgj6",
+        "sampleUnitRef": "dummy_6zfd5iq9pg",
+        "cohort": 7,
+        "gor9d": "dummy_99n62dhi40",
+        "laCode": "dummy_p468dsuyo5",
+        "uprnLatitude": "52.35064053950229",
+        "uprnLongitude": "-1.580400903268521"
+      },
+      "sampleSensitive": {
+        "phoneNumber": "REDACTED"
+      },
+      "caseRef": "10000000017",
+      "createdAt": "2021-01-01T01:02:03.456Z",
+      "lastUpdatedAt": "2021-10-10T00:00:00.000Z"
     }
   }
-]
+}

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.CaseUpdate.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.CaseUpdate.json
@@ -1,6 +1,5 @@
 {
   "caseId": "2883af91-0052-4497-9805-3238544fcf8a",
-  "caseRef": "10000000017",
   "surveyId": "2883af91-0052-4497-9805-3238544fcf8a",
   "collectionExerciseId": "3883af91-0052-4497-9805-3238544fcf8a",
   "invalid": true,
@@ -24,6 +23,7 @@
   "sampleSensitive": {
     "phoneNumber": "REDACTED"
   },
+  "caseRef": "10000000017",
   "createdAt": "2021-01-01T01:02:03.456Z",
   "lastUpdatedAt": "2021-10-10T00:00:00.000Z"
 }

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.CollectionExerciseUpdateEvent.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.CollectionExerciseUpdateEvent.json
@@ -18,10 +18,10 @@
       "startDate": "2021-09-17T23:59:59.999Z",
       "endDate": "2021-09-27T23:59:59.999Z",
       "metadata": {
-        "numberOfWaves": "3",
-        "waveLength": "2",
-        "cohorts": "3",
-        "cohortSchedule": "7"
+        "numberOfWaves": 3,
+        "waveLength": 2,
+        "cohorts": 3,
+        "cohortSchedule": 7
       }
     }
   }

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.FulfilmentEvent.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.FulfilmentEvent.json
@@ -1,77 +1,25 @@
-[
-  {
-    "header": {
-      "version": "0.4.0",
-      "topic": "event_fulfilment",
-      "source": "CONTACT_CENTRE_API",
-      "channel": "CC",
-      "dateTime": "2020-06-29T13:25:36.042Z",
-      "messageId": "1d91fec8-4f3a-4ce0-ad4f-165815bd5ec4",
-      "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
-      "originatingUser": "TBD"
-    },
-    "payload": {
-      "fulfilmentRequest": {
-        "fulfilmentCode": "ENH1",
-        "caseId": "id-123",
-        "individualCaseId": "ead8aa0e-793f-4489-ae26-1989e0bd76b1",
-        "contact": {
-          "title": "Ms",
-          "forename": "jo",
-          "surname": "smith",
-          "telNo": "+447890000000"
-        }
-      }
-    }
+{
+  "header": {
+    "version": "0.4.0",
+    "topic": "event_fulfilment",
+    "source": "CONTACT_CENTRE_API",
+    "channel": "CC",
+    "dateTime": "2020-06-29T13:25:36.042Z",
+    "messageId": "1d91fec8-4f3a-4ce0-ad4f-165815bd5ec4",
+    "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
+    "originatingUser": "TBD"
   },
-  {
-    "header": {
-      "version": "0.4.0",
-      "topic": "event_fulfilment",
-      "source": "CONTACT_CENTRE_API",
-      "channel": "CC",
-      "dateTime": "2020-06-29T13:25:36.042Z",
-      "messageId": "d82637e7-bf67-44fc-a1ce-1f4ecdf35ede",
-      "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
-      "originatingUser": "TBD"
-    },
-    "payload": {
-      "fulfilmentRequest": {
-        "fulfilmentCode": "ENH1",
-        "caseId": "id-123",
-        "individualCaseId": "ead8aa0e-793f-4489-ae26-1989e0bd76b1",
-        "contact": {
-          "title": "Ms",
-          "forename": "jo",
-          "surname": "smith",
-          "telNo": "+447890000000"
-        }
-      }
-    }
-  },
-  {
-    "header": {
-      "version": "0.4.0",
-      "topic": "event_fulfilment",
-      "source": "CONTACT_CENTRE_API",
-      "channel": "CC",
-      "dateTime": "2020-06-29T13:25:36.042Z",
-      "messageId": "9e6456e4-fe21-48c9-8f7d-46179ecbc3d3",
-      "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
-      "originatingUser": "TBD"
-    },
-    "payload": {
-      "fulfilmentRequest": {
-        "fulfilmentCode": "ENH1",
-        "caseId": "id-123",
-        "individualCaseId": "ead8aa0e-793f-4489-ae26-1989e0bd76b1",
-        "contact": {
-          "title": "Ms",
-          "forename": "jo",
-          "surname": "smith",
-          "telNo": "+447890000000"
-        }
+  "payload": {
+    "fulfilmentRequest": {
+      "fulfilmentCode": "ENH1",
+      "caseId": "id-123",
+      "individualCaseId": "ead8aa0e-793f-4489-ae26-1989e0bd76b1",
+      "contact": {
+        "title": "Ms",
+        "forename": "jo",
+        "surname": "smith",
+        "telNo": "+447890000000"
       }
     }
   }
-]
+}

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.NewCaseEvent.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.NewCaseEvent.json
@@ -1,0 +1,34 @@
+{
+  "header": {
+    "version": "0.4.0",
+    "topic": "event_new-case",
+    "source": "SAMPLE_LOADER",
+    "channel": "CC",
+    "dateTime": "2021-11-12T16:14:05.044Z",
+    "messageId": "c18ba0dd-c831-404e-96e0-50e589e28774",
+    "correlationId": "c18ba0dd-c831-404e-96e0-50e589e28774",
+    "originatingUser": "TBD"
+  },
+  "payload": {
+    "newCase": {
+      "caseId": "3883af91-0052-4497-9805-3238544fcf8a",
+      "collectionExerciseId": "22684ede-7d5f-4f53-9069-2398055c61b2",
+      "sample": {
+        "schoolId": "abc1234",
+        "schoolName": "Chesterthorps High School",
+        "consentGivenTest": "true",
+        "consentGivenSurvey": "true"
+      },
+      "sampleSensitive": {
+        "firstName": "Fred",
+        "lastName": "Bloggs",
+        "childFirstName": "Jo",
+        "childMiddleNames": "Rose",
+        "childLastName": "Bloggs",
+        "childDob": "2001-12-31",
+        "mobileNumber": "07123456999",
+        "emailAddress": "fred.bloggs@domain.com"
+      }
+    }
+  }
+}

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.RefusalEvent.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.RefusalEvent.json
@@ -1,20 +1,18 @@
-[
-  {
-    "header": {
-      "version": "0.4.0",
-      "topic": "event_refusal",
-      "source": "CONTACT_CENTRE_API",
-      "channel": "CC",
-      "dateTime": "2020-06-29T13:25:36.042Z",
-      "messageId": "2e62f0a2-d83f-43b2-97fc-d300e2ed59cb",
-      "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
-      "originatingUser": "TBD"
-    },
-    "payload": {
-      "refusal": {
-        "caseId": "18353ceb-28cf-4a64-bee2-c4dc556d1268",
-        "type": "EXTRAORDINARY_REFUSAL"
-      }
+{
+  "header": {
+    "version": "0.4.0",
+    "topic": "event_refusal",
+    "source": "CONTACT_CENTRE_API",
+    "channel": "CC",
+    "dateTime": "2020-06-29T13:25:36.042Z",
+    "messageId": "2e62f0a2-d83f-43b2-97fc-d300e2ed59cb",
+    "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
+    "originatingUser": "TBD"
+  },
+  "payload": {
+    "refusal": {
+      "caseId": "18353ceb-28cf-4a64-bee2-c4dc556d1268",
+      "type": "EXTRAORDINARY_REFUSAL"
     }
   }
-]
+}

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.SurveyLaunchEvent.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.SurveyLaunchEvent.json
@@ -1,21 +1,19 @@
-[
-  {
-    "header": {
-      "version": "0.4.0",
-      "topic": "event_survey-launch",
-      "source": "RESPONDENT_HOME",
-      "channel": "RH",
-      "dateTime": "2020-06-29T13:25:36.042Z",
-      "messageId": "14490f12-cb0b-459d-921e-cd4c59613268",
-      "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
-      "originatingUser": "TBD"
-    },
-    "payload": {
-      "response": {
-        "questionnaireId": "1110000009",
-        "caseId": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4",
-        "agentId" : "x1"
-      }
+{
+  "header": {
+    "version": "0.4.0",
+    "topic": "event_survey-launch",
+    "source": "RESPONDENT_HOME",
+    "channel": "RH",
+    "dateTime": "2020-06-29T13:25:36.042Z",
+    "messageId": "14490f12-cb0b-459d-921e-cd4c59613268",
+    "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
+    "originatingUser": "TBD"
+  },
+  "payload": {
+    "response": {
+      "questionnaireId": "1110000009",
+      "caseId": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4",
+      "agentId": "x1"
     }
   }
-]
+}

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.SurveyUpdateEvent.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.SurveyUpdateEvent.json
@@ -13,6 +13,7 @@
     "surveyUpdate": {
       "surveyId": "3883af91-0052-4497-9805-3238544fcf8a",
       "name": "LMS",
+      "sampleDefinitionUrl": "https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/social/0.1.0-DRAFT/social.json",
       "sampleDefinition": [
         {
           "columnName": "addressLine1",
@@ -94,8 +95,7 @@
       ],
       "metadata": {
         "ex_e4": true
-      },
-      "sampleDefinitionUrl": "https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/social/0.1.0-DRAFT/socsdial.json"
+      }
     }
   }
 }

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.UacAuthenticateEvent.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.UacAuthenticateEvent.json
@@ -1,20 +1,18 @@
-[
-  {
-    "header": {
-      "version": "0.4.0",
-      "topic": "event_uac-authenticate",
-      "source": "RESPONDENT_HOME",
-      "channel": "RH",
-      "dateTime": "2020-06-29T13:25:36.042Z",
-      "messageId": "ef23ec16-fab5-47bf-9e58-25fa6254b37e",
-      "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
-      "originatingUser": "RESPONDENT_HOME"
-    },
-    "payload": {
-      "response": {
-        "questionnaireId": "1110000009",
-        "caseId": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4"
-      }
+{
+  "header": {
+    "version": "0.4.0",
+    "topic": "event_uac-authenticate",
+    "source": "RESPONDENT_HOME",
+    "channel": "RH",
+    "dateTime": "2020-06-29T13:25:36.042Z",
+    "messageId": "ef23ec16-fab5-47bf-9e58-25fa6254b37e",
+    "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
+    "originatingUser": "RESPONDENT_HOME"
+  },
+  "payload": {
+    "response": {
+      "questionnaireId": "1110000009",
+      "caseId": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4"
     }
   }
-]
+}

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.UacEvent.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.UacEvent.json
@@ -1,27 +1,25 @@
-[
-  {
-    "header": {
-      "version": "0.4.0",
-      "topic": "event_uac-update",
-      "source": "RESPONDENT_HOME",
-      "channel": "RH",
-      "dateTime": "2020-06-29T13:25:36.042Z",
-      "messageId": "2985d223-e967-4c98-a3d5-07e4c9deeef4",
-      "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
-      "originatingUser": "RESPONDENT_HOME"
-    },
-    "payload": {
-      "uacUpdate": {
-        "caseId": "2d9beda1-b6d5-4abd-bff1-c4bd9eecac86",
-        "active": true,
-        "uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
-        "qid": "1110000009",
-        "receiptReceived": false,
-        "metadata": {
-          "wave": 94
-        },
-        "eqLaunched": true
-      }
+{
+  "header": {
+    "version": "0.4.0",
+    "topic": "event_uac-update",
+    "source": "RESPONDENT_HOME",
+    "channel": "RH",
+    "dateTime": "2020-06-29T13:25:36.042Z",
+    "messageId": "2985d223-e967-4c98-a3d5-07e4c9deeef4",
+    "correlationId": "3883af91-0052-4497-9805-3238544fcf8a",
+    "originatingUser": "RESPONDENT_HOME"
+  },
+  "payload": {
+    "uacUpdate": {
+      "caseId": "2d9beda1-b6d5-4abd-bff1-c4bd9eecac86",
+      "active": true,
+      "uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
+      "qid": "1110000009",
+      "receiptReceived": false,
+      "metadata": {
+        "wave": 94
+      },
+      "eqLaunched": true
     }
   }
-]
+}


### PR DESCRIPTION

SOCINT-243 was raised to document the issues found when a test of the eventpublisher had completely incorrect JSON fixture but the test still passed. Much of that issue was addressed by SOCINT-244 which was implemented in PR #32 , however the issue of missing implicit conversions such as between String and boolean remained. This is addressed in this PR with a new unit test for the pubsub sending to ensure that the JSON fixture matches the JSON sent to pubsub (when having gone through a Jackson deserialisation and serialisation cycle).

Changes:
- new unit test class to check all event JSON is as expected when sent
- modification of JSON fixtures for events to take out array wrapper, since the FixtureHelper "object node" methods do not cater for this.
- alter UacUpdate "active" flag to be boolean in line with RM and other fixtures and tests.
