### PR TITLE
Socint 242 survey endpoints

### DIFF
--- a/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/model/SurveyUpdate.java
+++ b/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/model/SurveyUpdate.java
@@ -42,6 +42,6 @@ public class SurveyUpdate implements EventPayload {
   }
 
   public SurveyType surveyType() {
-    return SurveyType.fromSurveyDefinitionUrl(sampleDefinitionUrl);
+    return SurveyType.fromSampleDefinitionUrl(sampleDefinitionUrl);
   }
 }

--- a/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/model/SurveyUpdate.java
+++ b/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/model/SurveyUpdate.java
@@ -7,6 +7,7 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.ons.ctp.common.domain.SurveyType;
 
 @Data
 @NoArgsConstructor
@@ -38,5 +39,9 @@ public class SurveyUpdate implements EventPayload {
   @JsonSetter("metadata")
   void setMetadataFromJson(JsonNode data) {
     this.metadata = data.toString();
+  }
+
+  public SurveyType surveyType() {
+    return SurveyType.fromSurveyDefinitionUrl(sampleDefinitionUrl);
   }
 }

--- a/event-publisher/src/test/java/uk/gov/ons/ctp/common/event/model/SurveyUpdateTest.java
+++ b/event-publisher/src/test/java/uk/gov/ons/ctp/common/event/model/SurveyUpdateTest.java
@@ -1,0 +1,43 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.ons.ctp.common.FixtureHelper;
+import uk.gov.ons.ctp.common.domain.SurveyType;
+
+public class SurveyUpdateTest {
+
+  private SurveyUpdate surveyUpdate;
+
+  @BeforeEach
+  public void setup() {
+    surveyUpdate = FixtureHelper.loadPackageFixtures(SurveyUpdate[].class).get(0);
+  }
+
+  @Test
+  public void shouldIdentifySocialType() {
+    surveyUpdate.setSampleDefinitionUrl("https://some.domain/path1/path2/social.json");
+    assertEquals(SurveyType.SOCIAL, surveyUpdate.surveyType());
+  }
+
+  @Test
+  public void shouldIdentifySisType() {
+    surveyUpdate.setSampleDefinitionUrl("https://some.domain/path1/path2/sis.json");
+    assertEquals(SurveyType.SIS, surveyUpdate.surveyType());
+  }
+
+  @Test
+  public void shouldNotRecogniseRandomUrlSuffix() {
+    surveyUpdate.setSampleDefinitionUrl("https://some.domain/path1/path2/random.json");
+    assertNull(surveyUpdate.surveyType());
+  }
+
+  @Test
+  public void shouldNotRecogniseNullSampleDefinitionUrl() {
+    surveyUpdate.setSampleDefinitionUrl(null);
+    assertNull(surveyUpdate.surveyType());
+  }
+}

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/model/PackageFixture.SurveyUpdate.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/model/PackageFixture.SurveyUpdate.json
@@ -1,0 +1,130 @@
+{
+  "surveyId": "5883af91-0052-4497-9805-3238544fcf8a",
+  "name": "LMS",
+  "sampleDefinition": [
+    {
+      "columnName": "addressLine1",
+      "rules": [
+        {
+          "className": "uk.gov.ons.ssdc.common.validation.MandatoryRule"
+        },
+        {
+          "className": "uk.gov.ons.ssdc.common.validation.LengthRule",
+          "maxLength": 60
+        }
+      ]
+    },
+    {
+      "columnName": "addressLine2",
+      "rules": [
+        {
+          "className": "uk.gov.ons.ssdc.common.validation.LengthRule",
+          "maxLength": 60
+        }
+      ]
+    },
+    {
+      "columnName": "addressLine3",
+      "rules": [
+        {
+          "className": "uk.gov.ons.ssdc.common.validation.LengthRule",
+          "maxLength": 60
+        }
+      ]
+    },
+    {
+      "columnName": "townName",
+      "rules": [
+        {
+          "className": "uk.gov.ons.ssdc.common.validation.MandatoryRule"
+        }
+      ]
+    },
+    {
+      "columnName": "postcode",
+      "rules": [
+        {
+          "className": "uk.gov.ons.ssdc.common.validation.MandatoryRule"
+        }
+      ]
+    },
+    {
+      "columnName": "region",
+      "rules": [
+        {
+          "className": "uk.gov.ons.ssdc.common.validation.InSetRule",
+          "set": [
+            "E",
+            "W",
+            "N"
+          ]
+        }
+      ]
+    },
+    {
+      "columnName": "uprn",
+      "rules": [
+        {
+          "className": "uk.gov.ons.ssdc.common.validation.MandatoryRule"
+        }
+      ]
+    },
+    {
+      "columnName": "phoneNumber",
+      "sensitive": true,
+      "rules": [
+        {
+          "className": "uk.gov.ons.ssdc.common.validation.RegexRule",
+          "expression": "^07[0-9]{9}$"
+        }
+      ]
+    }
+  ],
+  "allowedPrintFulfilments": [
+    {
+      "packCode": "replace-uac-en",
+      "description": "Replacement UAC - English",
+      "metadata": {
+        "suitableRegions": [
+          "E",
+          "N"
+        ]
+      }
+    },
+    {
+      "packCode": "replace-uac-cy",
+      "description": "Replacement UAC - English & Welsh",
+      "metadata": {
+        "suitableRegions": [
+          "W"
+        ]
+      }
+    }
+  ],
+  "allowedSmsFulfilments": [
+    {
+      "packCode": "replace-uac-en",
+      "description": "Replacement UAC - English",
+      "metadata": {
+        "suitableRegions": [
+          "E",
+          "N"
+        ]
+      }
+    },
+    {
+      "packCode": "replace-uac-cy",
+      "description": "Replacement UAC - English & Welsh",
+      "metadata": {
+        "suitableRegions": [
+          "W"
+        ]
+      }
+    }
+  ],
+  "allowedEmailFulfilments": [],
+  "metadata": {
+    "ex_e4": true
+  },
+  "sampleDefinitionUrl": "https://raw.githubusercontent.com/ONSdigital/ssdc-shared-events/main/sample/social/0.1.0-DRAFT/socsdial.json"
+}

--- a/framework/src/main/java/uk/gov/ons/ctp/common/cloud/CloudDataStore.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/cloud/CloudDataStore.java
@@ -22,6 +22,8 @@ public interface CloudDataStore {
   <T> List<T> search(Class<T> target, final String schema, String[] fieldPath, String searchValue)
       throws CTPException;
 
+  <T> List<T> list(Class<T> target, final String schema) throws CTPException;
+
   void deleteObject(final String schema, final String key) throws CTPException;
 
   Set<String> getCollectionNames();

--- a/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
@@ -184,7 +184,7 @@ public class FirestoreDataStore implements CloudDataStore {
   }
 
   /**
-   * List all objects found in the schema for the given schema.
+   * List all objects found in the given schema.
    *
    * @param <T> The object type that results should be returned in.
    * @param target the class of the object type that results should be returned in.

--- a/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.common.cloud;
 
+import static java.util.stream.Collectors.toList;
 import static uk.gov.ons.ctp.common.log.ScopedStructuredArguments.kv;
 
 import com.google.api.core.ApiFuture;
@@ -180,6 +181,36 @@ public class FirestoreDataStore implements CloudDataStore {
       throw new CTPException(Fault.SYSTEM_ERROR, failureMessage);
     }
     return result;
+  }
+
+  /**
+   * List all objects found in the schema for the given schema.
+   *
+   * @param <T> The object type that results should be returned in.
+   * @param target the class of the object type that results should be returned in.
+   * @param schema is the schema to search.
+   * @return the List of results.
+   * @throws CTPException if anything goes wrong.
+   */
+  @Override
+  public <T> List<T> list(Class<T> target, String schema) throws CTPException {
+    log.debug("Listing all items in Firestore", kv("schema", schema), kv("target", target));
+    try {
+      ApiFuture<QuerySnapshot> query = firestore.collection(schema).get();
+      QuerySnapshot querySnapshot = query.get();
+      List<QueryDocumentSnapshot> documents = querySnapshot.getDocuments();
+      return documents.stream().map(d -> d.toObject(target)).collect(toList());
+    } catch (Exception e) {
+      log.error(
+          "Failed to list Firestore items {} {}", kv("target", target), kv("schema", schema), e);
+      String failureMessage =
+          "Failed to list Firestore items. Target class: '"
+              + target
+              + "', schema: '"
+              + schema
+              + "'";
+      throw new CTPException(Fault.SYSTEM_ERROR, e, failureMessage);
+    }
   }
 
   /**

--- a/framework/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
@@ -64,6 +64,17 @@ public interface RetryableCloudDataStore {
       throws CTPException;
 
   /**
+   * List all objects found in the schema for the given schema.
+   *
+   * @param <T> The object type that results should be returned in.
+   * @param target the class of the object type that results should be returned in.
+   * @param schema is the schema to search.
+   * @return the List of results.
+   * @throws CTPException if anything goes wrong.
+   */
+  <T> List<T> list(Class<T> target, final String schema) throws CTPException;
+
+  /**
    * Runs an object search. This returns objects whose field is equal to the search value.
    *
    * @param <T> The object type that results should be returned in.

--- a/framework/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
@@ -64,7 +64,7 @@ public interface RetryableCloudDataStore {
       throws CTPException;
 
   /**
-   * List all objects found in the schema for the given schema.
+   * List all objects found in the given schema.
    *
    * @param <T> The object type that results should be returned in.
    * @param target the class of the object type that results should be returned in.

--- a/framework/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreImpl.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreImpl.java
@@ -57,6 +57,11 @@ public class RetryableCloudDataStoreImpl implements RetryableCloudDataStore {
   }
 
   @Override
+  public <T> List<T> list(Class<T> target, String schema) throws CTPException {
+    return cloudDataStore.list(target, schema);
+  }
+
+  @Override
   public <T> List<T> search(
       Class<T> target, final String schema, String[] fieldPathElements, String searchValue)
       throws CTPException {

--- a/framework/src/main/java/uk/gov/ons/ctp/common/domain/DeliveryChannel.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/domain/DeliveryChannel.java
@@ -1,0 +1,7 @@
+package uk.gov.ons.ctp.common.domain;
+
+public enum DeliveryChannel {
+  POST,
+  SMS,
+  EMAIL;
+}

--- a/framework/src/main/java/uk/gov/ons/ctp/common/domain/ProductGroup.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/domain/ProductGroup.java
@@ -1,0 +1,5 @@
+package uk.gov.ons.ctp.common.domain;
+
+public enum ProductGroup {
+  UAC
+}

--- a/framework/src/main/java/uk/gov/ons/ctp/common/domain/SurveyType.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/domain/SurveyType.java
@@ -1,17 +1,13 @@
 package uk.gov.ons.ctp.common.domain;
 
 public enum SurveyType {
-  SOCIAL("social.json"),
-  SIS("sis.json");
+  SOCIAL("social"),
+  SIS("sis");
 
   private String suffix;
 
   private SurveyType(String pattern) {
-    this.suffix = pattern;
-  }
-
-  public String getSuffix() {
-    return suffix;
+    this.suffix = pattern + ".json";
   }
 
   public static SurveyType fromSampleDefinitionUrl(String url) {

--- a/framework/src/main/java/uk/gov/ons/ctp/common/domain/SurveyType.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/domain/SurveyType.java
@@ -4,10 +4,16 @@ public enum SurveyType {
   SOCIAL("social"),
   SIS("sis");
 
+  private String basename;
   private String suffix;
 
-  private SurveyType(String pattern) {
-    this.suffix = pattern + ".json";
+  private SurveyType(String basename) {
+    this.basename = basename;
+    this.suffix = basename + ".json";
+  }
+
+  public String getBasename() {
+    return basename;
   }
 
   public static SurveyType fromSampleDefinitionUrl(String url) {

--- a/framework/src/main/java/uk/gov/ons/ctp/common/domain/SurveyType.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/domain/SurveyType.java
@@ -1,0 +1,25 @@
+package uk.gov.ons.ctp.common.domain;
+
+public enum SurveyType {
+  SOCIAL("social.json"),
+  SIS("sis.json");
+
+  private String pattern;
+
+  private SurveyType(String pattern) {
+    this.pattern = pattern;
+  }
+
+  public String getPattern() {
+    return pattern;
+  }
+
+  public static SurveyType fromSurveyDefinitionUrl(String url) {
+    for (SurveyType type : values()) {
+      if (url != null && url.endsWith(type.pattern)) {
+        return type;
+      }
+    }
+    return null;
+  }
+}

--- a/framework/src/main/java/uk/gov/ons/ctp/common/domain/SurveyType.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/domain/SurveyType.java
@@ -4,19 +4,19 @@ public enum SurveyType {
   SOCIAL("social.json"),
   SIS("sis.json");
 
-  private String pattern;
+  private String suffix;
 
   private SurveyType(String pattern) {
-    this.pattern = pattern;
+    this.suffix = pattern;
   }
 
-  public String getPattern() {
-    return pattern;
+  public String getSuffix() {
+    return suffix;
   }
 
-  public static SurveyType fromSurveyDefinitionUrl(String url) {
+  public static SurveyType fromSampleDefinitionUrl(String url) {
     for (SurveyType type : values()) {
-      if (url != null && url.endsWith(type.pattern)) {
+      if (url != null && url.endsWith(type.suffix)) {
         return type;
       }
     }


### PR DESCRIPTION
Changes supporting 2 new endpoints in RHSvc to get surveys.

- added `SurveyType`
- added couple of enums that were originally in product-reference, but that is now pencilled in for removal. They are needed by the RHSvc DTO's.
- added a `list` method to Firestore code. This will support the "get all surveys" endpoints.

JIRA LINK: https://collaborate2.ons.gov.uk/jira/browse/SOCINT-242