### PR TITLE
Socint 291 testcontainers firestore test

### DIFF
--- a/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/model/SurveyFulfilment.java
+++ b/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/model/SurveyFulfilment.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.common.event.model;
 
 import java.util.Map;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/model/SurveyUpdate.java
+++ b/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/model/SurveyUpdate.java
@@ -1,12 +1,10 @@
 package uk.gov.ons.ctp.common.event.model;
 
-import java.util.List;
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;
-
+import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/persistence/FirestoreEventPersistence.java
+++ b/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/persistence/FirestoreEventPersistence.java
@@ -22,7 +22,7 @@ public class FirestoreEventPersistence implements EventPersistence {
   private RetryableCloudDataStore cloudDataStore;
   private CustomObjectMapper objectMapper;
 
-  @Value("${GOOGLE_CLOUD_PROJECT}")
+  @Value("${spring.cloud.gcp.firestore.project-id}")
   String gcpProject;
 
   @Value("${cloud-storage.event-backup-schema-name}")

--- a/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
@@ -30,7 +30,7 @@ import uk.gov.ons.ctp.common.error.CTPException.Fault;
 @Service
 public class FirestoreDataStore implements CloudDataStore {
 
-  @Value("${GOOGLE_CLOUD_PROJECT}")
+  @Value("${spring.cloud.gcp.firestore.project-id}")
   private String gcpProject;
 
   private Firestore firestore;
@@ -38,7 +38,7 @@ public class FirestoreDataStore implements CloudDataStore {
   @PostConstruct
   public void create() {
     log.info("Connecting to Firestore project {}", gcpProject);
-    firestore = FirestoreOptions.getDefaultInstance().getService();
+    firestore = FirestoreOptions.newBuilder().setProjectId(gcpProject).build().getService();
   }
 
   /**

--- a/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
@@ -6,8 +6,6 @@ import static uk.gov.ons.ctp.common.log.ScopedStructuredArguments.kv;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.FieldPath;
-import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
 import com.google.cloud.firestore.WriteResult;
@@ -19,9 +17,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.CTPException.Fault;
@@ -30,16 +27,7 @@ import uk.gov.ons.ctp.common.error.CTPException.Fault;
 @Service
 public class FirestoreDataStore implements CloudDataStore {
 
-  @Value("${spring.cloud.gcp.firestore.project-id}")
-  private String gcpProject;
-
-  private Firestore firestore;
-
-  @PostConstruct
-  public void create() {
-    log.info("Connecting to Firestore project {}", gcpProject);
-    firestore = FirestoreOptions.newBuilder().setProjectId(gcpProject).build().getService();
-  }
+  @Autowired private FirestoreProvider provider;
 
   /**
    * Write object to Firestore collection. If the collection already holds an object with the
@@ -60,7 +48,7 @@ public class FirestoreDataStore implements CloudDataStore {
     log.info("Saving object to Firestore", kv("schema", schema), kv("key", key));
 
     // Store the object
-    ApiFuture<WriteResult> result = firestore.collection(schema).document(key).set(value);
+    ApiFuture<WriteResult> result = provider.get().collection(schema).document(key).set(value);
 
     // Wait for Firestore to complete
     try {
@@ -196,7 +184,7 @@ public class FirestoreDataStore implements CloudDataStore {
   public <T> List<T> list(Class<T> target, String schema) throws CTPException {
     log.debug("Listing all items in Firestore", kv("schema", schema), kv("target", target));
     try {
-      ApiFuture<QuerySnapshot> query = firestore.collection(schema).get();
+      ApiFuture<QuerySnapshot> query = provider.get().collection(schema).get();
       QuerySnapshot querySnapshot = query.get();
       List<QueryDocumentSnapshot> documents = querySnapshot.getDocuments();
       return documents.stream().map(d -> d.toObject(target)).collect(toList());
@@ -251,7 +239,7 @@ public class FirestoreDataStore implements CloudDataStore {
       throws CTPException {
     // Run a query
     ApiFuture<QuerySnapshot> query =
-        firestore.collection(schema).whereEqualTo(fieldPath, searchValue).get();
+        provider.get().collection(schema).whereEqualTo(fieldPath, searchValue).get();
 
     // Wait for query to complete and get results
     QuerySnapshot querySnapshot;
@@ -290,7 +278,7 @@ public class FirestoreDataStore implements CloudDataStore {
     log.info("Deleting object from Firestore", kv("schema", schema), kv("key", key));
 
     // Tell firestore to delete object
-    DocumentReference docRef = firestore.collection(schema).document(key);
+    DocumentReference docRef = provider.get().collection(schema).document(key);
     ApiFuture<WriteResult> result = docRef.delete();
 
     // Wait for delete to complete
@@ -313,7 +301,7 @@ public class FirestoreDataStore implements CloudDataStore {
   @Override
   public Set<String> getCollectionNames() {
     Set<String> collectionNames = new HashSet<>();
-    firestore.listCollections().forEach(c -> collectionNames.add(c.getId()));
+    provider.get().listCollections().forEach(c -> collectionNames.add(c.getId()));
     return collectionNames;
   }
 }

--- a/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreProvider.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreProvider.java
@@ -1,0 +1,7 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import com.google.cloud.firestore.Firestore;
+
+public interface FirestoreProvider {
+  Firestore get();
+}

--- a/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreProviderImpl.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreProviderImpl.java
@@ -1,0 +1,28 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class FirestoreProviderImpl implements FirestoreProvider {
+  @Value("${spring.cloud.gcp.firestore.project-id}")
+  private String gcpProject;
+
+  private Firestore firestore;
+
+  @PostConstruct
+  private void create() {
+    log.info("Connecting to Firestore project {}", gcpProject);
+    firestore = FirestoreOptions.newBuilder().setProjectId(gcpProject).build().getService();
+  }
+
+  @Override
+  public Firestore get() {
+    return firestore;
+  }
+}

--- a/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreProviderImpl.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreProviderImpl.java
@@ -16,7 +16,7 @@ public class FirestoreProviderImpl implements FirestoreProvider {
   private Firestore firestore;
 
   @PostConstruct
-  private void create() {
+  public void create() {
     log.info("Connecting to Firestore project {}", gcpProject);
     firestore = FirestoreOptions.newBuilder().setProjectId(gcpProject).build().getService();
   }

--- a/framework/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreImpl.java
+++ b/framework/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreImpl.java
@@ -23,11 +23,11 @@ import uk.gov.ons.ctp.common.error.CTPException.Fault;
 @Service
 public class RetryableCloudDataStoreImpl implements RetryableCloudDataStore {
 
-  private CloudDataStore cloudDataStore;
+  private FirestoreDataStore cloudDataStore;
   private Retrier retrier;
 
   @Autowired
-  public RetryableCloudDataStoreImpl(CloudDataStore cloudDataStore, Retrier retrier) {
+  public RetryableCloudDataStoreImpl(FirestoreDataStore cloudDataStore, Retrier retrier) {
     this.cloudDataStore = cloudDataStore;
     this.retrier = retrier;
   }
@@ -94,11 +94,11 @@ public class RetryableCloudDataStoreImpl implements RetryableCloudDataStore {
   @Slf4j
   @Component
   static class Retrier {
-    private CloudDataStore cloudDataStore;
+    private FirestoreDataStore cloudDataStore;
     private RetryConfig retryConfig;
 
     @Autowired
-    public Retrier(CloudDataStore cloudDataStore, RetryConfig retryConfig) {
+    public Retrier(FirestoreDataStore cloudDataStore, RetryConfig retryConfig) {
       this.cloudDataStore = cloudDataStore;
       this.retryConfig = retryConfig;
       log.info("CloudDataStore retry configuration: {}", this.retryConfig);

--- a/framework/src/test/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStoreTest.java
+++ b/framework/src/test/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStoreTest.java
@@ -41,10 +41,12 @@ public class FirestoreDataStoreTest extends CloudTestBase {
   private FirestoreDataStore firestoreDataStore = new FirestoreDataStore();
 
   @Mock private Firestore firestore;
+  @Mock private FirestoreProvider provider;
 
   @BeforeEach
   public void setUp() {
-    ReflectionTestUtils.setField(firestoreDataStore, "firestore", firestore);
+    ReflectionTestUtils.setField(firestoreDataStore, "provider", provider);
+    when(provider.get()).thenReturn(firestore);
   }
 
   @Test

--- a/framework/src/test/java/uk/gov/ons/ctp/common/cloud/Firestore_IT.java
+++ b/framework/src/test/java/uk/gov/ons/ctp/common/cloud/Firestore_IT.java
@@ -31,7 +31,7 @@ public class Firestore_IT extends CloudTestBase {
     firestoreDataStore = new FirestoreDataStore();
     ReflectionTestUtils.setField(
         firestoreDataStore, "gcpProject", System.getenv(FIRESTORE_PROJECT_ENV_NAME));
-    firestoreDataStore.create();
+    // firestoreDataStore.create(); // FIXME
   }
 
   @BeforeEach

--- a/framework/src/test/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreSpringTest.java
+++ b/framework/src/test/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreSpringTest.java
@@ -38,7 +38,7 @@ import uk.gov.ons.ctp.common.util.LockKey;
 @ResourceLock(value = LockKey.SPRING_TEST, mode = READ_WRITE)
 public class RetryableCloudDataStoreSpringTest extends CloudTestBase {
 
-  @MockBean private CloudDataStore cloudDataStore;
+  @MockBean private FirestoreDataStore cloudDataStore;
 
   @Autowired private RetryableCloudDataStore retryDataStore;
 

--- a/framework/src/test/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreTest.java
+++ b/framework/src/test/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreTest.java
@@ -28,7 +28,7 @@ import uk.gov.ons.ctp.common.error.CTPException.Fault;
 @ExtendWith(MockitoExtension.class)
 public class RetryableCloudDataStoreTest extends CloudTestBase {
 
-  @Mock private CloudDataStore cloudDataStore;
+  @Mock private FirestoreDataStore cloudDataStore;
 
   private RetryableCloudDataStoreImpl.Retrier retrier;
 

--- a/framework/src/test/java/uk/gov/ons/ctp/common/util/LockKey.java
+++ b/framework/src/test/java/uk/gov/ons/ctp/common/util/LockKey.java
@@ -1,6 +1,8 @@
 package uk.gov.ons.ctp.common.util;
 
 public class LockKey {
-  // Resource lock value for Spring tests in the framework project only
+  /** Resource lock value for Spring tests in the framework project only * */
   public static final String SPRING_TEST = "Spring-test";
+  /** Resource lock value for firestore tests in the framework project only * */
+  public static final String FIRESTORE_TEST = "Firestore-test";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.scm.id>ONS</project.scm.id>
+    <testcontainers.version>1.16.2</testcontainers.version>
   </properties>
 
   <dependencyManagement>
@@ -192,6 +193,51 @@
         <!-- WARNING changing the version of Nimbus may lead to loss of a deprecated Algorithm that may break EQ compatibility -->
         <version>8.1</version>
       </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Junit4 mocks allow us to remove the unwanted junit4 transitive dependency introduced by testcontainers
+      in a safe way. It is a minimal library of about 4 or 5 dummy interfaces. This will no longer be needed
+      when testcontainers moves to version 2 -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit4-mock</artifactId>
+      <version>2.5.0.Final</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>gcloud</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/test-framework/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreService.java
+++ b/test-framework/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreService.java
@@ -3,7 +3,6 @@ package uk.gov.ons.ctp.common.firestore;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.FieldPath;
 import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
 import lombok.extern.slf4j.Slf4j;
@@ -17,19 +16,12 @@ import uk.gov.ons.ctp.common.error.CTPException.Fault;
  */
 @Slf4j
 class FirestoreService {
-  private static FirestoreService instance = new FirestoreService();
-
   private Firestore firestore;
   private String gcpProject;
 
-  public static synchronized FirestoreService instance() {
-    return instance;
-  }
-
-  private FirestoreService() {
-    firestore = FirestoreOptions.getDefaultInstance().getService();
-
-    gcpProject = firestore.getOptions().getProjectId();
+  FirestoreService(Firestore firestore) {
+    this.firestore = firestore;
+    this.gcpProject = firestore.getOptions().getProjectId();
     log.info("Connected to Firestore project: " + gcpProject);
   }
 

--- a/test-framework/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreWait.java
+++ b/test-framework/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreWait.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.common.firestore;
 
+import com.google.cloud.firestore.Firestore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -26,6 +27,8 @@ import uk.gov.ons.ctp.common.error.CTPException.Fault;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FirestoreWait {
+
+  @NonNull private Firestore firestore;
 
   // This is the name of the collection to search, eg, 'case'
   @NonNull private String collection;
@@ -112,7 +115,7 @@ public class FirestoreWait {
     long objectUpdateTimestamp;
     do {
       objectUpdateTimestamp =
-          FirestoreService.instance()
+          new FirestoreService(firestore)
               .objectExists(collection, key, newerThan, contentCheckPath, expectedValue);
       if (objectUpdateTimestamp > 0) {
         log.debug("Found object");

--- a/test-framework/src/main/java/uk/gov/ons/ctp/common/firestore/TestCloudDataStore.java
+++ b/test-framework/src/main/java/uk/gov/ons/ctp/common/firestore/TestCloudDataStore.java
@@ -1,12 +1,5 @@
 package uk.gov.ons.ctp.common.firestore;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import javax.annotation.PostConstruct;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.Firestore;
@@ -14,6 +7,13 @@ import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
 import com.google.cloud.firestore.WriteResult;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.cloud.CloudDataStore;
 import uk.gov.ons.ctp.common.cloud.FirestoreDataStore;
 import uk.gov.ons.ctp.common.error.CTPException;

--- a/test-framework/src/main/java/uk/gov/ons/ctp/common/firestore/TestCloudDataStore.java
+++ b/test-framework/src/main/java/uk/gov/ons/ctp/common/firestore/TestCloudDataStore.java
@@ -1,0 +1,130 @@
+package uk.gov.ons.ctp.common.firestore;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.QuerySnapshot;
+import com.google.cloud.firestore.WriteResult;
+import uk.gov.ons.ctp.common.cloud.CloudDataStore;
+import uk.gov.ons.ctp.common.cloud.FirestoreDataStore;
+import uk.gov.ons.ctp.common.error.CTPException;
+
+/** Access the Cloud data store for testing purposes. */
+@Component
+public class TestCloudDataStore implements CloudDataStore {
+  private static final int DELETION_BATCH_SIZE = 100;
+
+  @Autowired private FirestoreDataStore dataStore;
+
+  private Firestore firestore;
+
+  @PostConstruct
+  public void create() {
+    firestore = FirestoreOptions.getDefaultInstance().getService();
+  }
+
+  public long deleteCollection(String schema) {
+    CollectionReference collection = firestore.collection(schema);
+
+    long totalDeleted = 0;
+    int numDeletedInBatch = 0;
+    do {
+      numDeletedInBatch = deleteBatch(collection);
+      totalDeleted += numDeletedInBatch;
+    } while (numDeletedInBatch >= DELETION_BATCH_SIZE);
+
+    return totalDeleted;
+  }
+
+  @Override
+  public void deleteObject(String schema, String key) throws CTPException {
+    dataStore.deleteObject(schema, key);
+  }
+
+  @Override
+  public Set<String> getCollectionNames() {
+    return dataStore.getCollectionNames();
+  }
+
+  @Override
+  public <T> Optional<T> retrieveObject(Class<T> target, String schema, String key)
+      throws CTPException {
+    return dataStore.retrieveObject(target, schema, key);
+  }
+
+  @Override
+  public <T> List<T> list(Class<T> target, String schema) throws CTPException {
+    return dataStore.list(target, schema);
+  }
+
+  @Override
+  public <T> List<T> search(Class<T> target, String schema, String[] fieldPath, String searchValue)
+      throws CTPException {
+    return dataStore.search(target, schema, fieldPath, searchValue);
+  }
+
+  @Override
+  public void storeObject(String schema, String key, Object value) throws CTPException {
+    try {
+      dataStore.storeObject(schema, key, value);
+    } catch (CTPException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Wait for an object to appear in the cloud data store.
+   *
+   * <p>See {@link FirestoreWait} for more details on behaviour.
+   *
+   * @param collection the collection name
+   * @param key the key of the object
+   * @param timeoutMillis timeout in milliseconds
+   * @return true if the object is found; false if the object is not found within the timeout
+   * @throws CTPException on error.
+   */
+  public boolean waitForObject(String collection, String key, long timeoutMillis)
+      throws CTPException {
+
+    if (collection == null || key == null) {
+      throw new IllegalArgumentException("collection and key must be provided");
+    }
+
+    FirestoreWait firestore =
+        FirestoreWait.builder().collection(collection).key(key).timeout(timeoutMillis).build();
+
+    return firestore.waitForObject() != null;
+  }
+
+  // there is no firestore method to delete a collection, so we delete in batches.
+  private int deleteBatch(CollectionReference collection) {
+    int deleted = 0;
+    try {
+      List<ApiFuture<WriteResult>> deleteFutures = new ArrayList<>();
+      ApiFuture<QuerySnapshot> batchCollectionFuture = collection.limit(DELETION_BATCH_SIZE).get();
+      List<QueryDocumentSnapshot> documents = batchCollectionFuture.get().getDocuments();
+      for (QueryDocumentSnapshot document : documents) {
+        deleteFutures.add(document.getReference().delete());
+      }
+      // wait for all deletes to finish
+      for (var f : deleteFutures) {
+        f.get();
+        ++deleted;
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return deleted;
+  }
+}

--- a/test-framework/src/main/java/uk/gov/ons/ctp/common/firestore/TestCloudDataStore.java
+++ b/test-framework/src/main/java/uk/gov/ons/ctp/common/firestore/TestCloudDataStore.java
@@ -2,8 +2,6 @@ package uk.gov.ons.ctp.common.firestore;
 
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.CollectionReference;
-import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
 import com.google.cloud.firestore.WriteResult;
@@ -11,12 +9,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.cloud.CloudDataStore;
 import uk.gov.ons.ctp.common.cloud.FirestoreDataStore;
+import uk.gov.ons.ctp.common.cloud.FirestoreProvider;
 import uk.gov.ons.ctp.common.error.CTPException;
 
 /** Access the Cloud data store for testing purposes. */
@@ -26,18 +23,10 @@ public class TestCloudDataStore implements CloudDataStore {
 
   @Autowired private FirestoreDataStore dataStore;
 
-  @Value("${spring.cloud.gcp.firestore.project-id}")
-  private String gcpProject;
-
-  private Firestore firestore;
-
-  @PostConstruct
-  public void create() {
-    firestore = FirestoreOptions.newBuilder().setProjectId(gcpProject).build().getService();
-  }
+  @Autowired private FirestoreProvider provider;
 
   public long deleteCollection(String schema) {
-    CollectionReference collection = firestore.collection(schema);
+    CollectionReference collection = provider.get().collection(schema);
 
     long totalDeleted = 0;
     int numDeletedInBatch = 0;
@@ -110,7 +99,7 @@ public class TestCloudDataStore implements CloudDataStore {
             .collection(collection)
             .key(key)
             .timeout(timeoutMillis)
-            .firestore(firestore)
+            .firestore(provider.get())
             .build();
 
     return firestoreWait.waitForObject() != null;


### PR DESCRIPTION
Changes to support running firestore emulator tests under TestContainers in RHSv integration tests. This follows on from the work done in SOCINT-278 to introduce postgres testing in CCSvc using TestContainers.

Changes:
- **GOOGLE_CLOUD_PROJECT** is not referenced directly; instead we use a spring property (chosen to match standard spring property for firestore project-id). This makes it easier for the tests to control which firestore is being used.
- introduce a `FirestoreProvider` class which can be switched to use the emulator
- move `TestCloudDataStore` from the cucumber-common project to test-framework. This supports batch deletion to allow firestore tests to start of a clean basis.

JIRA LINK: https://collaborate2.ons.gov.uk/jira/browse/SOCINT-291