### PR TITLE
SOCINT-333 make compatible with actual RM Case API datetime

### DIFF
--- a/case-api-client/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/EventDTO.java
+++ b/case-api-client/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/EventDTO.java
@@ -1,7 +1,9 @@
 package uk.gov.ons.ctp.integration.caseapiclient.caseservice.model;
 
+import java.time.LocalDateTime;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.util.Date;
+
 import lombok.Data;
 
 @Data
@@ -14,5 +16,5 @@ public class EventDTO {
 
   private String description;
 
-  private Date createdDateTime;
+  private LocalDateTime createdDateTime;
 }

--- a/case-api-client/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/RmCaseDTO.java
+++ b/case-api-client/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/RmCaseDTO.java
@@ -1,12 +1,11 @@
 package uk.gov.ons.ctp.integration.caseapiclient.caseservice.model;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import lombok.Data;
 
@@ -16,10 +15,8 @@ public class RmCaseDTO {
 
   private String caseRef;
 
-  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
   private LocalDateTime createdDateTime;
 
-  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
   private LocalDateTime lastUpdated;
 
   private List<EventDTO> caseEvents;

--- a/case-api-client/src/test/resources/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceTest.RmCaseDTO.json
+++ b/case-api-client/src/test/resources/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceTest.RmCaseDTO.json
@@ -2,8 +2,8 @@
 {
   "id": "b7565b5e-1396-4965-91a2-918c0d3642ed",
   "caseRef": "52224",
-  "createdDateTime": "2019-05-14T16:11:41.343+01:00",
-  "lastUpdated": "2019-05-14T16:15:32.221+01:00",
+  "createdDateTime": "2022-01-01T12:47:31.64708Z",
+  "lastUpdated": "2022-01-01T12:47:31.64708Z",
   "invalid" : false,
   "refusalType" : "SOFT_REFUSAL",
   "sample" : {
@@ -22,21 +22,21 @@
       "id": "101",
       "eventType": "CASE_CREATED",
       "description": "Initial creation of case",
-      "createdDateTime": "2019-05-14T16:11:41.343Z"
+      "createdDateTime": "2022-01-01T12:47:31.64708Z"
     },
     {
       "id": "102",
       "eventType": "CASE_UPDATED",
       "description": "Create Household Visit",
-      "createdDateTime": "2019-05-15T17:02:12.343+04:00"
+      "createdDateTime": "2022-01-01T12:47:31.64708Z"
     }
   ]
 },
 {
   "id": "b7565b5e-2222-2222-2222-918c0d3642ed",
   "caseRef": "52224",
-  "createdDateTime": "2019-05-14T16:11:41.343+01:00",
-  "lastUpdated": "2019-05-14T16:15:32.221+01:00",
+  "createdDateTime": "2022-01-01T12:47:31.64708Z",
+  "lastUpdated": "2022-01-01T12:47:31.64708Z",
   "invalid" : false,
   "refusalType" : "SOFT_REFUSAL",
   "sample" : {
@@ -55,21 +55,21 @@
       "id": "101",
       "category": "CASE_CREATED",
       "description": "Initial creation of case",
-      "createdDateTime": "2019-05-14T16:11:41.343Z"
+      "createdDateTime": "2022-01-01T12:47:31.64708Z"
     },
     {
       "id": "102",
       "category": "CASE_UPDATED",
       "description": "Create Household Visit",
-      "createdDateTime": "2019-05-15T17:02:12.343+04:00"
+      "createdDateTime": "2022-01-01T12:47:31.64708Z"
     }
   ]
 },
 {
   "id": "603d440b-18a0-41a0-992a-e12ea858ed35",
   "caseRef": "52224",
-  "createdDateTime": "2019-05-14T16:11:41.343+01:00",
-  "lastUpdated": "2019-05-14T16:15:32.221+01:00",
+  "createdDateTime": "2022-01-01T12:47:31.64708Z",
+  "lastUpdated": "2022-01-01T12:47:31.64708Z",
   "invalid" : false,
   "refusalType" : "SOFT_REFUSAL",
   "sample" : {
@@ -88,13 +88,13 @@
       "id": "101",
       "category": "CASE_CREATED",
       "description": "Initial creation of case",
-      "createdDateTime": "2019-05-14T16:11:41.343Z"
+      "createdDateTime": "2022-01-01T12:47:31.64708Z"
     },
     {
       "id": "102",
       "category": "CASE_UPDATED",
       "description": "Create Household Visit",
-      "createdDateTime": "2019-05-15T17:02:12.343+04:00"
+      "createdDateTime": "2022-01-01T12:47:31.64708Z"
     }
   ]
 }


### PR DESCRIPTION
While updating mock-service to handle case events, I made the mock use mock DTOs rather than just json string.
In doing so I aligned those DTOs with the current RM code base, and noticed that our case api client was not compatible re: datetime fields