### PR TITLE
SOCINT-329 add WITHDRAWAL_REFUSAL as a refusal type, and eraseData at…

### DIFF
--- a/case-api-client/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/RefusalType.java
+++ b/case-api-client/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/RefusalType.java
@@ -3,5 +3,6 @@ package uk.gov.ons.ctp.integration.caseapiclient.caseservice.model;
 public enum RefusalType {
   HARD_REFUSAL,
   EXTRAORDINARY_REFUSAL,
-  SOFT_REFUSAL
+  SOFT_REFUSAL,
+  WITHDRAWAL_REFUSAL
 }

--- a/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/model/RefusalDetails.java
+++ b/event-publisher/src/main/java/uk/gov/ons/ctp/common/event/model/RefusalDetails.java
@@ -12,4 +12,5 @@ public class RefusalDetails implements EventPayload {
 
   private UUID caseId;
   private String type;
+  private boolean eraseData;
 }

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.RefusalDetails.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.RefusalDetails.json
@@ -1,4 +1,5 @@
 {
   "caseId" : "18353ceb-28cf-4a64-bee2-c4dc556d1268",
-  "type" : "EXTRAORDINARY_REFUSAL"
+  "type" : "EXTRAORDINARY_REFUSAL",
+  "eraseData": false
 }

--- a/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.RefusalEvent.json
+++ b/event-publisher/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.RefusalEvent.json
@@ -12,7 +12,8 @@
   "payload": {
     "refusal": {
       "caseId": "18353ceb-28cf-4a64-bee2-c4dc556d1268",
-      "type": "EXTRAORDINARY_REFUSAL"
+      "type": "EXTRAORDINARY_REFUSAL",
+      "eraseData": false
     }
   }
 }


### PR DESCRIPTION
…tribute

- add `WITHDRAWAL_REFUSAL` as an extra refusal type
- add `eraseData` boolean

This matches the Event Dictionary 0.6.0-DRAFT

JIRA LINK: https://collaborate2.ons.gov.uk/jira/browse/SOCINT-329